### PR TITLE
Documentation Revision

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -47,6 +47,6 @@ Using our *source*
 
     If you would like to try-out the *latest* bits, you can clone a local version of our public source code repository on `GitHub <https://github.com/telesign>`_, and then install from your enlistment, as in the following example::
     
-        $ git clone git://github.com/TeleSign/telesign_python.git telesign
+        $ git clone git://github.com/TeleSign/python_telesign.git telesign
         $ cd telesign/
         $ python setup.py install


### PR DESCRIPTION
In the Installation.rst filie, in the section "Installing, Using our Source": Corrected the name of our respository.

Original:   telesign_python.git
Revised:    python_telesign.git
