### PR TITLE
suggesting url for client portal as currently link appears to be broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ For more examples, see the Documentation section below.
 Authentication
 --------------
 
-You will need a Customer ID and API Key in order to use TeleSign’s REST API.  If you are already a customer and need an API Key, you can generate one in the `Client Portal <https://portal.telesign.com>`_.  If you are not a customer and would like to get an API Key, please contact `support@telesign.com <mailto:support@telesign.com>`_
+You will need a Customer ID and API Key in order to use TeleSign’s REST API.  If you are already a customer and need an API Key, you can generate one in the `Client Portal <https://teleportal.telesign.com>`_.  If you are not a customer and would like to get an API Key, please contact `support@telesign.com <mailto:support@telesign.com>`_
 
 Documentation
 -------------


### PR DESCRIPTION
This patch proposes a new link as the correct link for the Client Portal.
Currently, the README file points to this link for the Client Portal: https://portal.telesign.com.
This link appears to be broken. The correct link appears to be: https://teleportal.telesign.com.

