### PR TITLE
Fix verify_code usage in Verify.smart

### DIFF
--- a/telesign/api.py
+++ b/telesign/api.py
@@ -1170,6 +1170,9 @@ class Verify(ServiceBase):
             'ucid': use_case_code,
         }
 
+        if verify_code:
+            fields['verify_code'] = verify_code
+
         if preference:
             fields['preference'] = preference
 


### PR DESCRIPTION
The parameter verify_code is optional for Verify.smart but was not added to the request.